### PR TITLE
Add support for Virtual DNS user analytics

### DIFF
--- a/virtualdns.go
+++ b/virtualdns.go
@@ -2,6 +2,9 @@ package cloudflare
 
 import (
 	"encoding/json"
+	"net/url"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -18,6 +21,31 @@ type VirtualDNS struct {
 	ModifiedOn           string   `json:"modified_on"`
 }
 
+// VirtualDNSAnalyticsMetrics respresents a group of aggregated Virtual DNS metrics.
+type VirtualDNSAnalyticsMetrics struct {
+	QueryCount         *int64   `json:"queryCount"`
+	UncachedCount      *int64   `json:"uncachedCount"`
+	StaleCount         *int64   `json:"staleCount"`
+	ResponseTimeAvg    *float64 `json:"responseTimeAvg"`
+	ResponseTimeMedian *float64 `json:"responseTimeMedian"`
+	ResponseTime90th   *float64 `json:"responseTime90th"`
+	ResponseTime99th   *float64 `json:"responseTime99th"`
+}
+
+// VirtualDNSAnalytics represents a set of aggregated Virtual DNS metrics.
+// TODO: Add the queried data and not only the aggregated values.
+type VirtualDNSAnalytics struct {
+	Totals VirtualDNSAnalyticsMetrics `json:"totals"`
+	Min    VirtualDNSAnalyticsMetrics `json:"min"`
+	Max    VirtualDNSAnalyticsMetrics `json:"max"`
+}
+
+type VirtualDNSUserAnalyticsOptions struct {
+	Metrics []string
+	Since   *time.Time
+	Until   *time.Time
+}
+
 // VirtualDNSResponse represents a Virtual DNS response.
 type VirtualDNSResponse struct {
 	Response
@@ -28,6 +56,12 @@ type VirtualDNSResponse struct {
 type VirtualDNSListResponse struct {
 	Response
 	Result []*VirtualDNS `json:"result"`
+}
+
+// VirtualDNSAnalyticsResponse represents a Virtual DNS analytics response.
+type VirtualDNSAnalyticsResponse struct {
+	Response
+	Result VirtualDNSAnalytics `json:"result"`
 }
 
 // CreateVirtualDNS creates a new Virtual DNS cluster.
@@ -122,4 +156,35 @@ func (api *API) DeleteVirtualDNS(virtualDNSID string) error {
 	}
 
 	return nil
+}
+
+// encode encodes non-nil fields into URL encoded form.
+func (o VirtualDNSUserAnalyticsOptions) encode() string {
+	v := url.Values{}
+	if o.Since != nil {
+		v.Set("since", (*o.Since).Format(time.RFC3339))
+	}
+	if o.Until != nil {
+		v.Set("until", (*o.Until).Format(time.RFC3339))
+	}
+	if o.Metrics != nil {
+		v.Set("metrics", strings.Join(o.Metrics, ","))
+	}
+	return v.Encode()
+}
+
+func (api *API) VirtualDNSUserAnalytics(virtualDNSID string, o VirtualDNSUserAnalyticsOptions) (VirtualDNSAnalytics, error) {
+	uri := "/user/virtual_dns/" + virtualDNSID + "/dns_analytics/report?" + o.encode()
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return VirtualDNSAnalytics{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := VirtualDNSAnalyticsResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return VirtualDNSAnalytics{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response.Result, nil
 }

--- a/virtualdns.go
+++ b/virtualdns.go
@@ -162,10 +162,10 @@ func (api *API) DeleteVirtualDNS(virtualDNSID string) error {
 func (o VirtualDNSUserAnalyticsOptions) encode() string {
 	v := url.Values{}
 	if o.Since != nil {
-		v.Set("since", (*o.Since).Format(time.RFC3339))
+		v.Set("since", (*o.Since).UTC().Format(time.RFC3339))
 	}
 	if o.Until != nil {
-		v.Set("until", (*o.Until).Format(time.RFC3339))
+		v.Set("until", (*o.Until).UTC().Format(time.RFC3339))
 	}
 	if o.Metrics != nil {
 		v.Set("metrics", strings.Join(o.Metrics, ","))

--- a/virtualdns_test.go
+++ b/virtualdns_test.go
@@ -1,0 +1,84 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func float64Ptr(v float64) *float64 {
+	return &v
+}
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+func TestVirtualDNSUserAnalytics(t *testing.T) {
+	setup()
+	defer teardown()
+
+	since := time.Now().Add(-1 * time.Hour)
+	until := time.Now()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		expectedMetrics := "queryCount,uncachedCount,staleCount,responseTimeAvg,responseTimeMedia,responseTime90th,responseTime99th"
+
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET'")
+		assert.Equal(t, expectedMetrics, r.URL.Query().Get("metrics"), "Expected many metrics in URL parameter")
+		assert.Equal(t, since.Format(time.RFC3339), r.URL.Query().Get("since"), "Expected since parameter in URL")
+		assert.Equal(t, until.Format(time.RFC3339), r.URL.Query().Get("until"), "Expected until parameter in URL")
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "result": {
+			"totals":{
+				"queryCount": 5,
+				"uncachedCount":6,
+				"staleCount":7,
+				"responseTimeAvg":1.0,
+				"responseTimeMedian":2.0,
+				"responseTime90th":3.0,
+				"responseTime99th":4.0
+			  }
+		  },
+		  "success": true,
+		  "errors": null,
+		  "messages": null
+		}`)
+	}
+
+	mux.HandleFunc("/user/virtual_dns/12345/dns_analytics/report", handler)
+	want := VirtualDNSAnalytics{
+		Totals: VirtualDNSAnalyticsMetrics{
+			QueryCount:         int64Ptr(5),
+			UncachedCount:      int64Ptr(6),
+			StaleCount:         int64Ptr(7),
+			ResponseTimeAvg:    float64Ptr(1.0),
+			ResponseTimeMedian: float64Ptr(2.0),
+			ResponseTime90th:   float64Ptr(3.0),
+			ResponseTime99th:   float64Ptr(4.0),
+		},
+	}
+
+	params := VirtualDNSUserAnalyticsOptions{
+		Metrics: []string{
+			"queryCount",
+			"uncachedCount",
+			"staleCount",
+			"responseTimeAvg",
+			"responseTimeMedia",
+			"responseTime90th",
+			"responseTime99th",
+		},
+		Since: &since,
+		Until: &until,
+	}
+	actual, err := client.VirtualDNSUserAnalytics("12345", params)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}


### PR DESCRIPTION
In order to make it possible to implement a Prometheus exporter for virtual DNS metrics.